### PR TITLE
✨ Use pagination and Backend Filtering

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -79,3 +79,23 @@ This change focuses on improving the search and filtering experience for advocat
 Overall, these changes make the advocate search experience more robust, user-friendly, and maintainable for future development.
 
 ---
+
+# Pagination Improvements
+### Summary of Changes
+
+This change focuses on implementing a pagination for the back and front end of the service. 
+
+- **Improved Speed:** The pagination prevents the DB from needing to query *all* potential advocates at once and then needing to filter everything.
+- **Filtering on the **
+- **Better UX:** Users should have a better experience than endlessly scrolling down the advocates page.
+
+---
+
+# Future updates
+
+1. I would update the available location filter to be more dynamic, right now it's dependent on just the current locations that advocates currently are. This is, one not efficient with many results, and two is a bit frustrating to have to scroll through. I would make this a location picker. 
+2. I would update the specialties filters, "popular searches" and other fields related to specifics for the advocates to be fetched from the database, not created on the frontend.
+3. I would update the advocate cards to be clickable, and transition you to a new "profile" page for those advocates, given we had more data and information on those advocates
+4. I would also like to implement a "compare" tool that you could easily copare multiple advocates at once, instead of having to scroll between the two.
+5. Finally, I'd like to improve the loading state, as it has a bit of a flash when loading new results.
+

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -86,7 +86,7 @@ Overall, these changes make the advocate search experience more robust, user-fri
 This change focuses on implementing a pagination for the back and front end of the service. 
 
 - **Improved Speed:** The pagination prevents the DB from needing to query *all* potential advocates at once and then needing to filter everything.
-- **Filtering on the **
+- **Filtering on Backend:** Use filtering through the backend, instead of filtering given results on the frontend
 - **Better UX:** Users should have a better experience than endlessly scrolling down the advocates page.
 
 ---

--- a/drizzle/0000_curly_ben_parker.sql
+++ b/drizzle/0000_curly_ben_parker.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "advocates" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"city" text NOT NULL,
+	"degree" text NOT NULL,
+	"payload" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"years_of_experience" integer NOT NULL,
+	"phone_number" bigint NOT NULL,
+	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP
+);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,82 @@
+{
+  "id": "507f5f33-f4e1-4322-a4e0-22715b7d69a7",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.advocates": {
+      "name": "advocates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "degree": {
+          "name": "degree",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "years_of_experience": {
+          "name": "years_of_experience",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1753057831332,
+      "tag": "0000_curly_ben_parker",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "^14.2.19",
         "postgres": "^3.4.4",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "swr": "^2.3.4"
       },
       "devDependencies": {
         "@types/node": "^20.14.12",
@@ -2057,6 +2058,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/didyoumean": {
@@ -5363,6 +5373,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.16",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
@@ -5622,6 +5645,15 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "next": "^14.2.19",
     "postgres": "^3.4.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "swr": "^2.3.4"
   },
   "devDependencies": {
     "@types/node": "^20.14.12",

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,174 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
+import { sql, count, ilike, and, gte, lte, or } from "drizzle-orm";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    
+    // Pagination parameters
+    const page = parseInt(searchParams.get('page') || '1');
+    const limit = parseInt(searchParams.get('limit') || '10');
+    const offset = (page - 1) * limit;
+    
+    // Filter parameters
+    const searchTerm = searchParams.get('search') || '';
+    const specialty = searchParams.get('specialty') || '';
+    const city = searchParams.get('city') || '';
+    const minExperience = searchParams.get('minExperience');
+    const maxExperience = searchParams.get('maxExperience');
 
-  const data = advocateData;
+    // Check if we have a valid database connection
+    if (db) {
+      try {
+        // Database-based filtering with SQL
+        const whereConditions = [];
+        
+        if (searchTerm) {
+          whereConditions.push(
+            or(
+              ilike(advocates.firstName, `%${searchTerm}%`),
+              ilike(advocates.lastName, `%${searchTerm}%`),
+              ilike(advocates.city, `%${searchTerm}%`),
+              ilike(advocates.degree, `%${searchTerm}%`),
+              sql`${advocates.yearsOfExperience}::text ILIKE ${`%${searchTerm}%`}`,
+              sql`${advocates.specialties}::text ILIKE ${`%${searchTerm}%`}`
+            )
+          );
+        }
+        
+        if (specialty) {
+          whereConditions.push(
+            sql`${advocates.specialties}::text ILIKE ${`%${specialty}%`}`
+          );
+        }
+        
+        if (city) {
+          whereConditions.push(ilike(advocates.city, `%${city}%`));
+        }
+        
+        if (minExperience) {
+          whereConditions.push(gte(advocates.yearsOfExperience, parseInt(minExperience)));
+        }
+        
+        if (maxExperience) {
+          whereConditions.push(lte(advocates.yearsOfExperience, parseInt(maxExperience)));
+        }
 
-  return Response.json({ data });
+        const whereClause = whereConditions.length > 0 ? and(...whereConditions) : undefined;
+
+        // Get total count for pagination metadata
+        const totalCountResult = whereClause 
+          ? await db.select({ count: count() }).from(advocates).where(whereClause)
+          : await db.select({ count: count() }).from(advocates);
+        
+        const total = totalCountResult[0].count;
+
+        // Get paginated and filtered data
+        const data = whereClause
+          ? await db.select().from(advocates).where(whereClause).limit(limit).offset(offset).orderBy(advocates.id)
+          : await db.select().from(advocates).limit(limit).offset(offset).orderBy(advocates.id);
+
+        // Calculate pagination metadata
+        const totalPages = Math.ceil(total / limit);
+        const hasNextPage = page < totalPages;
+        const hasPrevPage = page > 1;
+
+        return Response.json({
+          data,
+          pagination: {
+            page,
+            limit,
+            total,
+            totalPages,
+            hasNextPage,
+            hasPrevPage
+          }
+        });
+
+      } catch (dbError) {
+        console.warn('Database query failed, falling back to static data:', dbError);
+        // Fall through to static data handling
+      }
+    }
+
+    // Fallback to in-memory filtering with static data
+    let filteredData = [...advocateData];
+
+    // Apply search term filter
+    if (searchTerm) {
+      const normalizedSearchTerm = searchTerm.toLowerCase().trim();
+      filteredData = filteredData.filter((advocate) => {
+        const searchFields = [
+          advocate.firstName.toLowerCase(),
+          advocate.lastName.toLowerCase(),
+          advocate.city.toLowerCase(),
+          advocate.degree.toLowerCase(),
+          advocate.yearsOfExperience.toString(),
+          ...advocate.specialties.map(s => s.toLowerCase())
+        ];
+        
+        return searchFields.some(field => field.includes(normalizedSearchTerm));
+      });
+    }
+
+    // Apply specialty filter
+    if (specialty) {
+      filteredData = filteredData.filter(advocate => 
+        advocate.specialties.some(s => 
+          s.toLowerCase().includes(specialty.toLowerCase())
+        )
+      );
+    }
+
+    // Apply city filter
+    if (city) {
+      filteredData = filteredData.filter(advocate => 
+        advocate.city.toLowerCase().includes(city.toLowerCase())
+      );
+    }
+
+    // Apply experience filter
+    if (minExperience) {
+      filteredData = filteredData.filter(advocate => 
+        advocate.yearsOfExperience >= parseInt(minExperience)
+      );
+    }
+
+    if (maxExperience) {
+      filteredData = filteredData.filter(advocate => 
+        advocate.yearsOfExperience <= parseInt(maxExperience)
+      );
+    }
+
+    const total = filteredData.length;
+
+    // Apply pagination to the filtered data
+    const data = filteredData.slice(offset, offset + limit);
+
+    // Calculate pagination metadata
+    const totalPages = Math.ceil(total / limit);
+    const hasNextPage = page < totalPages;
+    const hasPrevPage = page > 1;
+
+    return Response.json({
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages,
+        hasNextPage,
+        hasPrevPage
+      }
+    });
+
+  } catch (error) {
+    console.error('Error fetching advocates:', error);
+    return Response.json(
+      { error: 'Failed to fetch advocates' },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/components/Advocates/AdvocatesGrid.tsx
+++ b/src/app/components/Advocates/AdvocatesGrid.tsx
@@ -1,17 +1,27 @@
 "use client";
 
 import { useAdvocatesContext } from "../../context/AdvocatesContext";
+import LoadingState from "../LoadingState";
+import NoResultsState from "../NoResultsState";
 import AdvocateCard from "./AdvocateCard";
 
 export default function AdvocatesGrid() {
-  const { filteredAdvocates, searchResults } = useAdvocatesContext();
+  const { advocates, searchResults, pagination, isLoading, searchTerm } = useAdvocatesContext();
+
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (!searchResults.hasResults) {
+    return <NoResultsState searchTerm={searchTerm} />;
+  }
 
   return (
     <div className="space-y-4">
       {/* View Toggle - Could add table/card view toggle here */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-gray-600">
-          Showing {searchResults.total} advocate{searchResults.total !== 1 ? 's' : ''}
+          Showing {advocates.length} of {searchResults.total} advocate{searchResults.total !== 1 ? 's' : ''}
         </p>
         <div className="flex items-center space-x-2 text-sm text-gray-500">
           <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -23,20 +33,21 @@ export default function AdvocatesGrid() {
 
       {/* Advocates Grid */}
       <div className="space-y-4">
-        {filteredAdvocates.map((advocate, index) => (
+        {advocates.map((advocate, index) => (
           <AdvocateCard 
-            key={`advocate-${index}`} 
+            key={`advocate-${advocate.id || index}`} 
             advocate={advocate} 
             searchTerm={searchResults.highlightedSearchTerm}
           />
         ))}
       </div>
 
-      {/* Load More / Pagination could go here if needed */}
-      {filteredAdvocates.length > 10 && (
+      {/* Pagination info */}
+      {pagination.totalPages > 1 && (
         <div className="text-center pt-6">
           <p className="text-sm text-gray-500">
-            Showing all {filteredAdvocates.length} results
+            Page {pagination.page} of {pagination.totalPages} 
+            ({pagination.total} total results)
           </p>
         </div>
       )}

--- a/src/app/components/AdvocatesPageContent.tsx
+++ b/src/app/components/AdvocatesPageContent.tsx
@@ -8,16 +8,21 @@ import NoResultsState from "./NoResultsState";
 import SearchBar from "./SearchBar";
 import FilterPanel from "./FilterPanel";
 import { AdvocatesGrid } from "./Advocates";
+import Pagination from "./Pagination";
 import { useAdvocatesContext } from "../context/AdvocatesContext";
 
 import SolaceLogo from "@/app/public/solace.svg";
 
 export default function AdvocatesPageContent() {
   const {
-    isLoading,
     error,
     searchResults,
-    searchTerm
+    searchTerm,
+    pagination,
+    goToPage,
+    nextPage,
+    prevPage,
+    setPageSize
   } = useAdvocatesContext();
 
   return (
@@ -71,29 +76,31 @@ export default function AdvocatesPageContent() {
         {/* Error State */}
         {error && <ErrorState error={error} />}
 
-        {isLoading && <LoadingState />}
-
         {/* Results Section */}
-        {!isLoading && !error && (
-            <div className="bg-white rounded-xl shadow-lg border border-gray-200">
-            {searchResults.hasResults ? (
-                <div className="p-6">
-                <div className="flex items-center justify-between mb-6">
-                    <h2 className="text-2xl font-semibold text-gray-800">
-                    Available Advocates
-                    </h2>
-                    <div className="text-sm text-gray-500">
-                    Showing {searchResults.total} results
-                    </div>
-                </div>
-                <AdvocatesGrid />
-                </div>
-            ) : (
-                <div className="p-6">
-                <NoResultsState searchTerm={searchTerm} />
-                </div>
-            )}
-            </div>
+        {!error && (
+          <div className="bg-white rounded-xl shadow-lg border border-gray-200">
+						<div className="p-6">
+							<div className="flex items-center justify-between mb-6">
+							<h2 className="text-2xl font-semibold text-gray-800" id="available-advocates">
+								Available Advocates
+							</h2>
+							{searchResults.hasResults && (
+								<div className="text-sm text-gray-500">
+									Showing {pagination.page} of {pagination.totalPages} pages
+								</div>
+							)}
+							</div>
+							<AdvocatesGrid />
+						</div>
+						{/* Pagination Component */}
+						<Pagination
+							pagination={pagination}
+							onPageChange={goToPage}
+							onNextPage={nextPage}
+							onPrevPage={prevPage}
+							onPageSizeChange={setPageSize}
+						/>
+          </div>
         )}
 
         {/* Help Section */}

--- a/src/app/components/Pagination.tsx
+++ b/src/app/components/Pagination.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import React from 'react';
+import { PaginationData } from '../hooks/useAdvocates';
+
+interface PaginationProps {
+  pagination: PaginationData;
+  onPageChange: (page: number) => void;
+  onNextPage: () => void;
+  onPrevPage: () => void;
+  onPageSizeChange: (size: number) => void;
+}
+
+const Pagination: React.FC<PaginationProps> = ({
+  pagination,
+  onPageChange,
+  onNextPage,
+  onPrevPage,
+  onPageSizeChange,
+}) => {
+  const { page, totalPages, hasNextPage, hasPrevPage, total, limit } = pagination;
+
+  // Generate page numbers to show
+  const getPageNumbers = () => {
+    const pages = [];
+    const maxVisiblePages = 5;
+    
+    if (totalPages <= maxVisiblePages) {
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      let start = Math.max(1, page - Math.floor(maxVisiblePages / 2));
+      let end = Math.min(totalPages, start + maxVisiblePages - 1);
+      
+      if (end === totalPages) {
+        start = Math.max(1, end - maxVisiblePages + 1);
+      }
+      
+      if (start > 1) {
+        pages.push(1);
+        if (start > 2) pages.push('...');
+      }
+      
+      for (let i = start; i <= end; i++) {
+        pages.push(i);
+      }
+      
+      if (end < totalPages) {
+        if (end < totalPages - 1) pages.push('...');
+        pages.push(totalPages);
+      }
+    }
+    
+    return pages;
+  };
+
+  const startItem = (page - 1) * limit + 1;
+  const endItem = Math.min(page * limit, total);
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 p-4 bg-gray-50 border-t border-gray-200">
+      {/* Results info and page size selector */}
+      <div className="flex flex-col sm:flex-row items-center gap-4 text-sm text-gray-600">
+        <div>
+          Showing {startItem}-{endItem} of {total} results
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="pageSize" className="text-sm font-medium">
+            Show:
+          </label>
+          <select
+            id="pageSize"
+            value={limit}
+            onChange={(e) => onPageSizeChange(Number(e.target.value))}
+            className="px-2 py-1 border border-gray-300 rounded text-sm focus:outline-none focus:ring-2 focus:ring-teal-500"
+          >
+            <option value={5}>5</option>
+            <option value={10}>10</option>
+            <option value={20}>20</option>
+            <option value={50}>50</option>
+          </select>
+          <span className="text-sm">per page</span>
+        </div>
+      </div>
+
+      {/* Pagination controls */}
+      {totalPages > 1 && (
+        <div className="flex items-center gap-2">
+          {/* Previous button */}
+          <button
+            onClick={onPrevPage}
+            disabled={!hasPrevPage}
+            className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+              hasPrevPage
+                ? 'text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-teal-500'
+                : 'text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed'
+            }`}
+          >
+            Previous
+          </button>
+
+          {/* Page numbers */}
+          <div className="flex items-center gap-1">
+            {getPageNumbers().map((pageNum, index) => (
+              <React.Fragment key={index}>
+                {pageNum === '...' ? (
+                  <span className="px-3 py-2 text-gray-400">...</span>
+                ) : (
+                  <button
+                    onClick={() => onPageChange(pageNum as number)}
+                    className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+                      pageNum === page
+                        ? 'text-white bg-teal-600 border border-teal-600'
+                        : 'text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-teal-500'
+                    }`}
+                  >
+                    {pageNum}
+                  </button>
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+
+          {/* Next button */}
+          <button
+            onClick={onNextPage}
+            disabled={!hasNextPage}
+            className={`px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+              hasNextPage
+                ? 'text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-teal-500'
+                : 'text-gray-400 bg-gray-100 border border-gray-200 cursor-not-allowed'
+            }`}
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Pagination; 

--- a/src/app/hooks/useAdvocates.ts
+++ b/src/app/hooks/useAdvocates.ts
@@ -1,9 +1,18 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from 'react';
+import useSWR from 'swr';
 import { Advocate } from '../types/advocates';
+
+export interface PaginationData {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+}
 
 export interface UseAdvocatesReturn {
   advocates: Advocate[];
-  filteredAdvocates: Advocate[];
   searchTerm: string;
   isLoading: boolean;
   error: string | null;
@@ -18,14 +27,32 @@ export interface UseAdvocatesReturn {
     hasResults: boolean;
     highlightedSearchTerm: string;
   };
+  pagination: PaginationData;
+  goToPage: (page: number) => void;
+  nextPage: () => void;
+  prevPage: () => void;
+  setPageSize: (size: number) => void;
+  activeFilters: {
+    specialty: string;
+    city: string;
+    minExperience: number;
+    maxExperience: number;
+  };
 }
 
+// SWR fetcher function
+const fetcher = async (url: string) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return response.json();
+};
+
 export const useAdvocates = (): UseAdvocatesReturn => {
-  const [advocates, setAdvocates] = useState<Advocate[]>([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState<Advocate[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>('');
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [pageSize, setPageSize] = useState<number>(10);
   const [activeFilters, setActiveFilters] = useState({
     specialty: '',
     city: '',
@@ -33,32 +60,52 @@ export const useAdvocates = (): UseAdvocatesReturn => {
     maxExperience: 50,
   });
 
-  // Fetch advocates on mount
-  useEffect(() => {
-    const fetchAdvocates = async () => {
-      setIsLoading(true);
-      setError(null);
-      
-      try {
-        const response = await fetch('/api/advocates');
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        const jsonResponse = await response.json();
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-        setError(`Error fetching advocates: ${errorMessage}`);
-        setAdvocates([]);
-        setFilteredAdvocates([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  // Build query parameters for API call
+  const queryParams = useMemo(() => {
+    const params = new URLSearchParams({
+      page: currentPage.toString(),
+      limit: pageSize.toString(),
+    });
 
-    fetchAdvocates();
-  }, []);
+    if (searchTerm.trim()) {
+      params.append('search', searchTerm.trim());
+    }
+    if (activeFilters.specialty) {
+      params.append('specialty', activeFilters.specialty);
+    }
+    if (activeFilters.city) {
+      params.append('city', activeFilters.city);
+    }
+    if (activeFilters.minExperience > 0) {
+      params.append('minExperience', activeFilters.minExperience.toString());
+    }
+    if (activeFilters.maxExperience < 50) {
+      params.append('maxExperience', activeFilters.maxExperience.toString());
+    }
+
+    return params.toString();
+  }, [currentPage, pageSize, searchTerm, activeFilters]);
+
+  // SWR hook for data fetching
+  const { data, error, isLoading, mutate } = useSWR(
+    `/api/advocates?${queryParams}`,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: true,
+      dedupingInterval: 5000,
+    }
+  );
+
+  const advocates = data?.data || [];
+  const pagination = data?.pagination || {
+    page: 1,
+    limit: 10,
+    total: 0,
+    totalPages: 0,
+    hasNextPage: false,
+    hasPrevPage: false,
+  };
 
   // Debounced search function
   const debouncedSearch = useMemo(() => {
@@ -67,78 +114,29 @@ export const useAdvocates = (): UseAdvocatesReturn => {
     return (searchValue: string) => {
       clearTimeout(timeoutId);
       timeoutId = setTimeout(() => {
-        applyFilters(searchValue);
+        setSearchTerm(searchValue);
+        setCurrentPage(1); // Reset to first page on search
       }, 300);
     };
-  }, [advocates, activeFilters]);
-
-  // Apply all filters including search term
-  const applyFilters = useCallback((searchValue: string = searchTerm) => {
-    let filtered = [...advocates];
-
-    // Apply search term filter
-    if (searchValue.trim()) {
-      const normalizedSearchTerm = searchValue.toLowerCase().trim();
-      filtered = filtered.filter((advocate: Advocate) => {
-        const searchFields = [
-          advocate.firstName.toLowerCase(),
-          advocate.lastName.toLowerCase(),
-          advocate.city.toLowerCase(),
-          advocate.degree.toLowerCase(),
-          advocate.yearsOfExperience.toString(),
-          ...advocate.specialties.map(s => s.toLowerCase())
-        ];
-        
-        return searchFields.some(field => field.includes(normalizedSearchTerm));
-      });
-    }
-
-    // Apply specialty filter
-    if (activeFilters.specialty) {
-      filtered = filtered.filter(advocate => 
-        advocate.specialties.some(specialty => 
-          specialty.toLowerCase().includes(activeFilters.specialty.toLowerCase())
-        )
-      );
-    }
-
-    // Apply city filter
-    if (activeFilters.city) {
-      filtered = filtered.filter(advocate => 
-        advocate.city.toLowerCase().includes(activeFilters.city.toLowerCase())
-      );
-    }
-
-    // Apply experience filter
-    filtered = filtered.filter(advocate => 
-      advocate.yearsOfExperience >= activeFilters.minExperience &&
-      advocate.yearsOfExperience <= activeFilters.maxExperience
-    );
-
-    setFilteredAdvocates(filtered);
-  }, [advocates, searchTerm, activeFilters]);
-
-  // Re-apply filters when advocates or filters change
-  useEffect(() => {
-    applyFilters();
-  }, [applyFilters]);
+  }, []);
 
   const searchAdvocates = useCallback((term: string) => {
-    setSearchTerm(term);
     debouncedSearch(term);
   }, [debouncedSearch]);
 
   const clearSearch = useCallback(() => {
     setSearchTerm('');
-    applyFilters('');
-  }, [applyFilters]);
+    setCurrentPage(1);
+  }, []);
 
   const filterBySpecialty = useCallback((specialty: string) => {
     setActiveFilters(prev => ({ ...prev, specialty }));
+    setCurrentPage(1); // Reset to first page on filter change
   }, []);
 
   const filterByCity = useCallback((city: string) => {
     setActiveFilters(prev => ({ ...prev, city }));
+    setCurrentPage(1); // Reset to first page on filter change
   }, []);
 
   const filterByExperience = useCallback((minYears: number, maxYears: number) => {
@@ -147,6 +145,7 @@ export const useAdvocates = (): UseAdvocatesReturn => {
       minExperience: minYears, 
       maxExperience: maxYears 
     }));
+    setCurrentPage(1); // Reset to first page on filter change
   }, []);
 
   const resetFilters = useCallback(() => {
@@ -157,20 +156,44 @@ export const useAdvocates = (): UseAdvocatesReturn => {
       maxExperience: 50,
     });
     setSearchTerm('');
+    setCurrentPage(1);
+  }, []);
+
+  // Pagination controls
+  const goToPage = useCallback((page: number) => {
+    if (page >= 1 && page <= pagination.totalPages) {
+      setCurrentPage(page);
+    }
+  }, [pagination.totalPages]);
+
+  const nextPage = useCallback(() => {
+    if (pagination.hasNextPage) {
+      setCurrentPage(prev => prev + 1);
+    }
+  }, [pagination.hasNextPage]);
+
+  const prevPage = useCallback(() => {
+    if (pagination.hasPrevPage) {
+      setCurrentPage(prev => prev - 1);
+    }
+  }, [pagination.hasPrevPage]);
+
+  const setPageSizeHandler = useCallback((size: number) => {
+    setPageSize(size);
+    setCurrentPage(1); // Reset to first page when changing page size
   }, []);
 
   const searchResults = useMemo(() => ({
-    total: filteredAdvocates.length,
-    hasResults: filteredAdvocates.length > 0,
+    total: pagination.total,
+    hasResults: advocates.length > 0,
     highlightedSearchTerm: searchTerm.trim(),
-  }), [filteredAdvocates.length, searchTerm]);
+  }), [pagination.total, advocates.length, searchTerm]);
 
   return {
     advocates,
-    filteredAdvocates,
     searchTerm,
     isLoading,
-    error,
+    error: error?.message || null,
     searchAdvocates,
     clearSearch,
     filterBySpecialty,
@@ -178,5 +201,11 @@ export const useAdvocates = (): UseAdvocatesReturn => {
     filterByExperience,
     resetFilters,
     searchResults,
+    pagination,
+    goToPage,
+    nextPage,
+    prevPage,
+    setPageSize: setPageSizeHandler,
+    activeFilters,
   };
 }; 

--- a/src/app/types/advocates.ts
+++ b/src/app/types/advocates.ts
@@ -1,4 +1,5 @@
 export type Advocate = {
+    id?: number;
     firstName: string;
     lastName: string;
     city: string;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,17 +4,18 @@ import postgres from "postgres";
 const setup = () => {
   if (!process.env.DATABASE_URL) {
     console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    return null;
   }
 
-  // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
-  return db;
+  try {
+    // for query purposes
+    const queryClient = postgres(process.env.DATABASE_URL);
+    const db = drizzle(queryClient);
+    return db;
+  } catch (error) {
+    console.error("Failed to connect to database:", error);
+    return null;
+  }
 };
 
 export default setup();


### PR DESCRIPTION
This change focuses on implementing a pagination for the back and front end of the service. 

- **Improved Speed:** The pagination prevents the DB from needing to query *all* potential advocates at once and then needing to filter everything.
- **Filtering on Backend:** Use filtering through the backend, instead of filtering given results on the frontend
- **Better UX:** Users should have a better experience than endlessly scrolling down the advocates page.
